### PR TITLE
Improve look of PayPal buttons in dark mode

### DIFF
--- a/app/(root)/order/[id]/order-details-table.tsx
+++ b/app/(root)/order/[id]/order-details-table.tsx
@@ -237,7 +237,7 @@ const OrderDetailsTable = ({
 
               {/* PayPal Payment */}
               {!isPaid && paymentMethod === 'PayPal' && (
-                <div>
+                <div style={{ colorScheme: 'none' }}>
                   <PayPalScriptProvider options={{ clientId: paypalClientId }}>
                     <PrintLoadingState />
                     <PayPalButtons


### PR DESCRIPTION
The PayPal buttons look bad in dark mode. Added style per https://stackoverflow.com/questions/72901261/paypal-react-js-buttons-background-color to improve.