### PR TITLE
Fix Link href URL in place-order page order items table

### DIFF
--- a/app/(root)/place-order/page.tsx
+++ b/app/(root)/place-order/page.tsx
@@ -89,7 +89,7 @@ const PlaceOrderPage = async () => {
                     <TableRow key={item.slug}>
                       <TableCell>
                         <Link
-                          href={`/product/{item.slug}`}
+                          href={`/product/${item.slug}`}
                           className='flex items-center'
                         >
                           <Image


### PR DESCRIPTION
The href attribute of the <Link component is missing the "$" in the template literal

Currently:

href={`/product/{item.slug}`}

Should be:

href={`/product/${item.slug}`}

The link is working correctly after the adjustment.